### PR TITLE
Command to export translations of existing enchantments

### DIFF
--- a/common/src/main/java/net/darkhax/enchdesc/DescriptionManager.java
+++ b/common/src/main/java/net/darkhax/enchdesc/DescriptionManager.java
@@ -17,18 +17,21 @@ public class DescriptionManager {
         this.config = config;
     }
 
+    public static String getKey(Enchantment ench) {
+
+        final String descKey = ench.getDescriptionId() + ".desc";
+
+        if (!I18n.exists(descKey) && I18n.exists(ench.getDescriptionId() + ".description")) {
+
+            return ench.getDescriptionId() + ".description";
+        }
+
+        return descKey;
+    }
+
     public MutableComponent get(Enchantment ench) {
 
-        return descriptions.computeIfAbsent(ench, e -> {
-
-            String descriptionKey = e.getDescriptionId() + ".desc";
-
-            if (!I18n.exists(descriptionKey) && I18n.exists(e.getDescriptionId() + ".description")) {
-
-                descriptionKey = e.getDescriptionId() + ".description";
-            }
-
-            return Component.translatable(descriptionKey).withStyle(config.style);
-        });
+        return descriptions.computeIfAbsent(ench, e ->
+            Component.translatable(getKey(e)).withStyle(config.style));
     }
 }

--- a/common/src/main/java/net/darkhax/enchdesc/commands/EnchantmentExporter.java
+++ b/common/src/main/java/net/darkhax/enchdesc/commands/EnchantmentExporter.java
@@ -1,0 +1,96 @@
+package net.darkhax.enchdesc.commands;
+
+import net.darkhax.enchdesc.Constants;
+import net.darkhax.enchdesc.DescriptionManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.enchantment.Enchantment;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class EnchantmentExporter {
+
+    public static int execute() {
+
+        final Minecraft mc = Minecraft.getInstance();
+        final String lang = mc.options.languageCode;
+
+        final File outputFile = new File(
+                mc.gameDirectory,
+                "kubejs/assets/enchanted-descriptions/" + lang + "_generated.json"
+        );
+        outputFile.getParentFile().mkdirs();
+
+        final List<ResourceLocation> sortedKeys = new ArrayList<>(BuiltInRegistries.ENCHANTMENT.keySet());
+        sortedKeys.sort(Comparator.comparing(ResourceLocation::getNamespace)
+                                  .thenComparing(ResourceLocation::getPath));
+
+        try (OutputStreamWriter writer = new OutputStreamWriter(
+                new FileOutputStream(outputFile, false), StandardCharsets.UTF_8)) {
+
+            final List<String> entryLines = new ArrayList<>();
+            final List<String> entryNamespaces = new ArrayList<>();
+
+            for (ResourceLocation key : sortedKeys) {
+
+                final Enchantment enchantment = BuiltInRegistries.ENCHANTMENT.get(key);
+
+                if (enchantment == null) {
+                    continue;
+                }
+
+                final String descKey = DescriptionManager.getKey(enchantment);
+                final String value = I18n.exists(descKey) ? escapeJson(I18n.get(descKey)) : "";
+                entryLines.add("    \"" + escapeJson(descKey) + "\": \"" + value + "\"");
+                entryNamespaces.add(key.getNamespace());
+            }
+
+            writer.write("{\n");
+
+            for (int i = 0; i < entryLines.size(); i++) {
+
+                if (i > 0 && !entryNamespaces.get(i).equals(entryNamespaces.get(i - 1))) {
+                    writer.write("\n");
+                }
+
+                writer.write(entryLines.get(i));
+                writer.write(i < entryLines.size() - 1 ? ",\n" : "\n");
+            }
+
+            writer.write("}\n");
+
+            final int count = entryLines.size();
+
+            mc.player.sendSystemMessage(Component.literal(
+                    "[" + Constants.MOD_NAME + "] Exported " + count +
+                    " enchantment descriptions in " + lang + " to: " + outputFile.getAbsolutePath()));
+            return count;
+
+        } catch (IOException e) {
+
+            Constants.LOG.error("Failed to export enchantment descriptions", e);
+            mc.player.sendSystemMessage(Component.literal(
+                    "[" + Constants.MOD_NAME + "] Export failed: " + e.getMessage()));
+            return 0;
+        }
+    }
+
+    private static String escapeJson(String input) {
+
+        return input.replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                    .replace("\n", "\\n")
+                    .replace("\r", "\\r")
+                    .replace("\t", "\\t");
+    }
+}

--- a/common/src/main/java/net/darkhax/enchdesc/commands/EnchantmentExporter.java
+++ b/common/src/main/java/net/darkhax/enchdesc/commands/EnchantmentExporter.java
@@ -27,7 +27,7 @@ public class EnchantmentExporter {
 
         final File outputFile = new File(
                 mc.gameDirectory,
-                "kubejs/assets/enchanted-descriptions/" + lang + "_generated.json"
+                "kubejs/assets/enchanted-descriptions/lang/" + lang + "_generated.json"
         );
         outputFile.getParentFile().mkdirs();
 

--- a/common/src/main/java/net/darkhax/enchdesc/commands/EnchantmentExporter.java
+++ b/common/src/main/java/net/darkhax/enchdesc/commands/EnchantmentExporter.java
@@ -27,7 +27,7 @@ public class EnchantmentExporter {
 
         final File outputFile = new File(
                 mc.gameDirectory,
-                "kubejs/assets/enchanted-descriptions/lang/" + lang + "_generated.json"
+                "kubejs/assets/enchdesc/lang/" + lang + "_generated.json"
         );
         outputFile.getParentFile().mkdirs();
 

--- a/fabric/src/main/java/net/darkhax/enchdesc/EnchDescFabric.java
+++ b/fabric/src/main/java/net/darkhax/enchdesc/EnchDescFabric.java
@@ -1,5 +1,6 @@
 package net.darkhax.enchdesc;
 
+import net.darkhax.enchdesc.commands.ExportCommand;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 
@@ -9,5 +10,6 @@ public class EnchDescFabric implements ClientModInitializer {
     public void onInitializeClient() {
 
         new EnchDescCommon(FabricLoader.getInstance().getConfigDir());
+        ExportCommand.register();
     }
 }

--- a/fabric/src/main/java/net/darkhax/enchdesc/commands/ExportCommand.java
+++ b/fabric/src/main/java/net/darkhax/enchdesc/commands/ExportCommand.java
@@ -1,0 +1,19 @@
+package net.darkhax.enchdesc.commands;
+
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+
+public class ExportCommand {
+
+    public static void register() {
+
+        ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) ->
+            dispatcher.register(
+                ClientCommandManager.literal("enchdesc")
+                    .then(ClientCommandManager.literal("export")
+                        .executes(ctx -> EnchantmentExporter.execute())
+                    )
+            )
+        );
+    }
+}

--- a/forge/src/main/java/net/darkhax/enchdesc/EnchDescForge.java
+++ b/forge/src/main/java/net/darkhax/enchdesc/EnchDescForge.java
@@ -1,5 +1,7 @@
 package net.darkhax.enchdesc;
 
+import net.darkhax.enchdesc.commands.ExportCommand;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -17,6 +19,7 @@ public class EnchDescForge {
         if (Environment.get().getDist().isClient()) {
 
             new EnchDescCommon(FMLPaths.CONFIGDIR.get());
+            MinecraftForge.EVENT_BUS.addListener(ExportCommand::onRegisterClientCommands);
         }
     }
 }

--- a/forge/src/main/java/net/darkhax/enchdesc/commands/ExportCommand.java
+++ b/forge/src/main/java/net/darkhax/enchdesc/commands/ExportCommand.java
@@ -1,0 +1,17 @@
+package net.darkhax.enchdesc.commands;
+
+import net.minecraft.commands.Commands;
+import net.minecraftforge.client.event.RegisterClientCommandsEvent;
+
+public class ExportCommand {
+
+    public static void onRegisterClientCommands(RegisterClientCommandsEvent event) {
+
+        event.getDispatcher().register(
+            Commands.literal("enchdesc")
+                .then(Commands.literal("export")
+                    .executes(ctx -> EnchantmentExporter.execute())
+                )
+        );
+    }
+}


### PR DESCRIPTION
Exported file is put into kubejs folder. User is expected to rename it to the correct language and update translations there

<img width="266" height="121" alt="image" src="https://github.com/user-attachments/assets/399bf799-a1c1-417e-a711-4126349c50fd" />

```
{
    "enchantment.minecraft.aqua_affinity.desc": "Increases mining speed while underwater.",
    "enchantment.minecraft.bane_of_arthropods.desc": "Increases damage against arthropods such as Spiders and Silverfish.",
    ...
}
```