### PR TITLE
Failsafes for Direct enchantment references

### DIFF
--- a/common/src/main/java/net/darkhax/enchdesc/common/impl/EnchdescMod.java
+++ b/common/src/main/java/net/darkhax/enchdesc/common/impl/EnchdescMod.java
@@ -6,6 +6,7 @@ import net.darkhax.pricklemc.common.api.config.ConfigManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.EnchantmentScreen;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
@@ -20,7 +21,6 @@ import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
-import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
@@ -65,10 +65,10 @@ public class EnchdescMod {
 
     public boolean canDisplayDescription(ItemStack stack) {
         return hasInitialized &&
-               config.enabled &&
-               hasEnchantments(stack) &&
-               (!config.only_on_books || stack.getItem() instanceof EnchantedBookItem) &&
-               (!config.only_in_enchanting_table || Minecraft.getInstance().screen instanceof EnchantmentScreen);
+                config.enabled &&
+                hasEnchantments(stack) &&
+                (!config.only_on_books || stack.getItem() instanceof EnchantedBookItem) &&
+                (!config.only_in_enchanting_table || Minecraft.getInstance().screen instanceof EnchantmentScreen);
     }
 
     public Component getKeybindText() {
@@ -84,16 +84,17 @@ public class EnchdescMod {
     }
 
     @Nullable
-    private ResourceKey<Enchantment> getKey(Holder<Enchantment> holder) {
-        if (holder.kind() == Holder.Kind.REFERENCE) {
-            return holder.unwrapKey().orElseThrow();
-        } else {
-            Level level = Minecraft.getInstance().level;
-            if (level != null) {
-                return level.registryAccess().registry(Registries.ENCHANTMENT).orElseThrow().getResourceKey(holder.unwrap().right().orElseThrow()).orElseThrow();
+    private static ResourceKey<Enchantment> getKey(Holder<Enchantment> holder) {
+        return holder.unwrapKey().orElseGet(() -> {
+            if (!Services.PLATFORM.isPhysicalClient()) {
+                return null;
             }
-        }
-        return null;
+            final ClientLevel level = Minecraft.getInstance().level;
+            if (level == null) {
+                return null;
+            }
+            return holder.unwrap().right().flatMap(e -> level.registryAccess().registry(Registries.ENCHANTMENT).flatMap(r -> r.getResourceKey(e))).orElse(null);
+        });
     }
 
     public void insertDescriptions(Holder<Enchantment> enchantment, int level, Consumer<Component> lines) {

--- a/common/src/main/java/net/darkhax/enchdesc/common/impl/EnchdescMod.java
+++ b/common/src/main/java/net/darkhax/enchdesc/common/impl/EnchdescMod.java
@@ -9,15 +9,18 @@ import net.minecraft.client.gui.screens.inventory.EnchantmentScreen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
+import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
@@ -80,8 +83,25 @@ public class EnchdescMod {
         return !stack.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY).isEmpty() || !stack.getOrDefault(DataComponents.STORED_ENCHANTMENTS, ItemEnchantments.EMPTY).isEmpty();
     }
 
+    @Nullable
+    private ResourceKey<Enchantment> getKey(Holder<Enchantment> holder) {
+        if (holder.kind() == Holder.Kind.REFERENCE) {
+            return holder.unwrapKey().orElseThrow();
+        } else {
+            Level level = Minecraft.getInstance().level;
+            if (level != null) {
+                return level.registryAccess().registry(Registries.ENCHANTMENT).orElseThrow().getResourceKey(holder.unwrap().right().orElseThrow()).orElseThrow();
+            }
+        }
+        return null;
+    }
+
     public void insertDescriptions(Holder<Enchantment> enchantment, int level, Consumer<Component> lines) {
-        final MutableComponent description = getDescription(enchantment, enchantment.unwrapKey().orElseThrow().location(), level);
+        ResourceKey<Enchantment> key = getKey(enchantment);
+        if (key == null) {
+            return;
+        }
+        final MutableComponent description = getDescription(enchantment, key.location(), level);
         if (description != null) {
             ComponentUtils.mergeStyles(description, config.style);
             lines.accept(config.prefix.copy().append(description).append(config.suffix));

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ jei_version=19.18.10.218
 crt_version=21.0.3
 
 # NeoForge
-neoforge_version=21.1.61
+neoforge_version=21.1.233
 neoforge_loader_version_range=[4,)
 
 # Fabric


### PR DESCRIPTION
Closes #325. If an ItemStack has a Holder$Direct for enchantments for whatever reason, attempts to get the enchantment key from Registry.getResourceKey instead; and if for some reason the game is showing an item tooltip before the level even exists _and_ that item has a Direct enchantment, it fails gracefully and just doesn't add anything to the tooltip.